### PR TITLE
Refactor to sync flight lookup

### DIFF
--- a/lib/susanin.js
+++ b/lib/susanin.js
@@ -99,7 +99,7 @@ function getFlightForTheDay(flightData, date) {
   }
 }
 
-async function getFlightsFromAirport(from, after, before) {
+function getFlightsFromAirport(from, after, before) {
   const results = [];
   const relevantFlights = allFlights.filter(flight => flight.from.iata === from);
 
@@ -171,14 +171,14 @@ function groupRoutes(routes) {
   return result;
 }
 
-async function pathFinder(from, to, date, minTransferTime) {
+function pathFinder(from, to, date, minTransferTime) {
   let leg1 = [];
   {
     const dateObj = new Date(date);
     dateObj.setHours(0, 0, 0, 0);
     const startTime = dateObj.getTime();
     const endTime = startTime + 24 * 60 * 60 * 1000;
-    const flights = await getFlightsFromAirport(from, startTime, endTime);
+    const flights = getFlightsFromAirport(from, startTime, endTime);
     leg1 = flights.map(flight => new Route([flight]));
   }
 
@@ -191,7 +191,7 @@ async function pathFinder(from, to, date, minTransferTime) {
 
     const startTime = route.sta + minTransferTime * 1000;
     const endTime = startTime + 3 * 24 * 60 * 60 * 1000;
-    const flights = await getFlightsFromAirport(route.to, startTime, endTime);
+    const flights = getFlightsFromAirport(route.to, startTime, endTime);
     for (const flight of flights) {
       const newRoute = route.addLegIfNotLooped(flight);
       if (newRoute) {
@@ -209,7 +209,7 @@ async function pathFinder(from, to, date, minTransferTime) {
 
     const startTime = route.sta + minTransferTime * 1000;
     const endTime = startTime + 3 * 24 * 60 * 60 * 1000;
-    const flights = await getFlightsFromAirport(route.to, startTime, endTime);
+    const flights = getFlightsFromAirport(route.to, startTime, endTime);
     for (const flight of flights) {
       if (flight.toAirport === to) {
         const newRoute = route.addLegIfNotLooped(flight);


### PR DESCRIPTION
## Summary
- remove `async` from `getFlightsFromAirport`
- update `pathFinder` to call it synchronously and make `pathFinder` a plain function

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c7d3384d0832dbf17b4488a8c5a02