### PR TITLE
Add shared date & duration helpers

### DIFF
--- a/components/Route.jsx
+++ b/components/Route.jsx
@@ -4,6 +4,7 @@ import React, { useState } from "react";
 import RouteLeg from "./RouteLeg";
 import TransferInfo from "./TransferInfo";
 import styles from "./Route.module.css";
+import { formatDuration } from "@/lib/timeFormat";
 
 const Route = ({ route }) => {
   const fastestRouteLegs = route.fastestRouteLegs;
@@ -17,23 +18,12 @@ const Route = ({ route }) => {
   const [availableOptions2, setAvailableOptions2] = useState(options2);
   const [availableOptions3, setAvailableOptions3] = useState(options3);
 
-  const formatTime = (seconds) => {
-    const days = Math.floor(seconds / 86400000);
-    const hours = Math.floor((seconds % 86400000) / 3600000);
-    const minutes = Math.floor((seconds % 3600000) / 60000);
-
-    if (days > 0) {
-      return `${days}d ${hours}h ${minutes}m`;
-    } else {
-      return `${hours}h ${minutes}m`;
-    }
-  };
 
   const calculateTravelTime = () => {
     const start = leg1.std;
     const end = leg3?.sta || leg2?.sta || leg1.sta;
 
-    return formatTime(end - start);
+    return formatDuration(end - start);
   };
 
   const handleChange = (legIndex, event) => {

--- a/components/RouteLeg.jsx
+++ b/components/RouteLeg.jsx
@@ -2,17 +2,7 @@
 
 import React from "react";
 import styles from "./RouteLeg.module.css";
-
-const formatDate = (timestamp, offset = 0) => {
-  const date = new Date(timestamp + offset * 60 * 1000);
-  const DD = date.getUTCDate().toString().padStart(2, '0');
-  const MM = (date.getUTCMonth() + 1).toString().padStart(2, '0');
-  const YYYY = date.getUTCFullYear();
-  const hh = date.getUTCHours().toString().padStart(2, '0');
-  const mm = date.getUTCMinutes().toString().padStart(2, '0');
-
-  return `${DD}.${MM}.${YYYY} ${hh}:${mm}`;
-}
+import { formatDate } from "@/lib/timeFormat";
 
 const RouteLeg = ({selected, options, onChange}) => {
   if (!selected) {

--- a/components/TransferInfo.jsx
+++ b/components/TransferInfo.jsx
@@ -2,18 +2,7 @@
 
 import React from "react";
 import styles from "./TransferInfo.module.css";
-
-const formatTime = (seconds) => {
-  const days = Math.floor(seconds / 86400000);
-  const hours = Math.floor((seconds % 86400000) / 3600000);
-  const minutes = Math.floor((seconds % 3600000) / 60000);
-
-  if (days > 0) {
-    return `${days}d ${hours}h ${minutes}m`;
-  } else {
-    return `${hours}h ${minutes}m`;
-  }
-}
+import { formatDuration } from "@/lib/timeFormat";
 
 const TransferInfo = ({leg1, leg2}) => {
   if (!leg1 || !leg2) {
@@ -23,7 +12,7 @@ const TransferInfo = ({leg1, leg2}) => {
   return (
     <div className={styles.wrapper}>
       <p className={styles.title}>Transfer</p>
-      <p className={styles.text}>{formatTime(leg2.std - leg1.sta)}</p>
+      <p className={styles.text}>{formatDuration(leg2.std - leg1.sta)}</p>
     </div>
   )
 }

--- a/lib/timeFormat.js
+++ b/lib/timeFormat.js
@@ -1,0 +1,22 @@
+export function formatDate(timestamp, offset = 0) {
+  const date = new Date(timestamp + offset * 60 * 1000);
+  const DD = date.getUTCDate().toString().padStart(2, '0');
+  const MM = (date.getUTCMonth() + 1).toString().padStart(2, '0');
+  const YYYY = date.getUTCFullYear();
+  const hh = date.getUTCHours().toString().padStart(2, '0');
+  const mm = date.getUTCMinutes().toString().padStart(2, '0');
+
+  return `${DD}.${MM}.${YYYY} ${hh}:${mm}`;
+}
+
+export function formatDuration(ms) {
+  const days = Math.floor(ms / 86400000);
+  const hours = Math.floor((ms % 86400000) / 3600000);
+  const minutes = Math.floor((ms % 3600000) / 60000);
+
+  if (days > 0) {
+    return `${days}d ${hours}h ${minutes}m`;
+  }
+
+  return `${hours}h ${minutes}m`;
+}


### PR DESCRIPTION
## Summary
- create `lib/timeFormat.js` exporting `formatDate` and `formatDuration`
- refactor `Route.jsx`, `RouteLeg.jsx`, `TransferInfo.jsx` to reuse helpers
- rename formatting helper to more descriptive name

## Testing
- `npm run lint` *(fails: `next` not found)*


------
https://chatgpt.com/codex/tasks/task_e_684c7d15aac8832dacc55d45d27197dc