### PR TITLE
Refactor pathFinder loops

### DIFF
--- a/lib/susanin.js
+++ b/lib/susanin.js
@@ -171,56 +171,50 @@ function groupRoutes(routes) {
   return result;
 }
 
-async function pathFinder(from, to, date, minTransferTime) {
-  let leg1 = [];
-  {
-    const dateObj = new Date(date);
-    dateObj.setHours(0, 0, 0, 0);
-    const startTime = dateObj.getTime();
-    const endTime = startTime + 24 * 60 * 60 * 1000;
-    const flights = await getFlightsFromAirport(from, startTime, endTime);
-    leg1 = flights.map(flight => new Route([flight]));
-  }
+function filterFlightsByDestination(flights, destination) {
+  return flights.filter(flight => !destination || flight.toAirport === destination);
+}
 
-  let leg2 = [];
-  for (const route of leg1) {
+async function buildInitialRoutes(from, date) {
+  const dateObj = new Date(date);
+  dateObj.setHours(0, 0, 0, 0);
+  const startTime = dateObj.getTime();
+  const endTime = startTime + 24 * 60 * 60 * 1000;
+  const flights = await getFlightsFromAirport(from, startTime, endTime);
+  return flights.map(flight => new Route([flight]));
+}
+
+async function expandRoutes(routes, to, minTransferTime, finalLeg = false) {
+  const results = [];
+
+  for (const route of routes) {
     if (route.to === to) {
-      leg2.push(route);
+      results.push(route);
       continue;
     }
 
     const startTime = route.sta + minTransferTime * 1000;
     const endTime = startTime + 3 * 24 * 60 * 60 * 1000;
     const flights = await getFlightsFromAirport(route.to, startTime, endTime);
-    for (const flight of flights) {
+
+    for (const flight of filterFlightsByDestination(flights, finalLeg ? to : null)) {
       const newRoute = route.addLegIfNotLooped(flight);
       if (newRoute) {
-        leg2.push(newRoute);
+        results.push(newRoute);
       }
     }
   }
 
-  let leg3 = [];
-  for (const route of leg2) {
-    if (route.to === to) {
-      leg3.push(route);
-      continue;
-    }
+  return results;
+}
 
-    const startTime = route.sta + minTransferTime * 1000;
-    const endTime = startTime + 3 * 24 * 60 * 60 * 1000;
-    const flights = await getFlightsFromAirport(route.to, startTime, endTime);
-    for (const flight of flights) {
-      if (flight.toAirport === to) {
-        const newRoute = route.addLegIfNotLooped(flight);
-        if (newRoute) {
-          leg3.push(newRoute);
-        }
-      }
-    }
-  }
+async function pathFinder(from, to, date, minTransferTime) {
+  let routes = await buildInitialRoutes(from, date);
 
-  return groupRoutes(leg3);
+  routes = await expandRoutes(routes, to, minTransferTime);
+  routes = await expandRoutes(routes, to, minTransferTime, true);
+
+  return groupRoutes(routes);
 }
 
 export { pathFinder, getFlightsBetween };


### PR DESCRIPTION
## Summary
- extract `buildInitialRoutes` for initial leg lookup
- use `buildInitialRoutes` in `pathFinder`

## Testing
- `npm run lint` *(fails: `next` not found)*


------
https://chatgpt.com/codex/tasks/task_e_684c80e64af4832d94f47513b8bb1972