### PR TITLE
Fix flights directory path resolution

### DIFF
--- a/lib/data.mjs
+++ b/lib/data.mjs
@@ -1,15 +1,17 @@
 import fs from 'fs';
+import path from 'path';
 const __dirname = import.meta.dirname;
 
 const allFlights = [];
 const allAirports = [];
 
 (() => {
-  const fileNames = fs.readdirSync(`./flights`).filter(name => name.endsWith('.json'));
+  const flightsDir = path.join(__dirname, '../flights');
+  const fileNames = fs.readdirSync(flightsDir).filter(name => name.endsWith('.json'));
   const airportsSet = new Set();
 
   for (const fileName of fileNames) {
-    const raw = fs.readFileSync(`./flights/${fileName}`, 'utf8');
+    const raw = fs.readFileSync(path.join(flightsDir, fileName), 'utf8');
     const flightData = JSON.parse(raw);
     if (!flightData.from || !flightData.to) {
       console.log(`Skipped ${fileName} due to missing from/to data`);


### PR DESCRIPTION
## Summary
- update `data.mjs` to load flights from `../flights`
- use `path.join` for constructing file paths

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c7d78cd4c832d84de96a3e24ea7f9