### PR TITLE
Create reusable update notification

### DIFF
--- a/app/[from]/[to]/[date]/page.js
+++ b/app/[from]/[to]/[date]/page.js
@@ -3,7 +3,8 @@ import { allAirports } from '@/lib/data.mjs';
 import SearchForm from '@/components/SearchForm';
 import Routes from '@/components/Routes';
 import BuyMeACoffee from '@/components/BuyMeACoffee';
-import styles from './page.module.css';
+import UpdateNotification from '@/components/UpdateNotification';
+import styles from '@/app/page.module.css';
 
 export default async function Results({ params, searchParams }) {
   const min = Number(searchParams.minTransferTime ?? 3 * 3600);
@@ -13,12 +14,7 @@ export default async function Results({ params, searchParams }) {
     <div className={styles.app}>
       <h1 className={styles.header}>Route Planner</h1>
 
-      <div className={styles.notification}>
-        <p>
-          📅 <strong>Site and timetable updated Jun 13, 2025.</strong> Report about issues:&nbsp;
-          <a href="mailto:artem@veikus.com">artem@veikus.com</a>
-        </p>
-      </div>
+      <UpdateNotification/>
 
       <SearchForm airports={allAirports}/>
 

--- a/app/page.module.css
+++ b/app/page.module.css
@@ -22,30 +22,6 @@
   right: 10px;
 }
 
-.notification {
-  background-color: #f9f5e3;
-  border: 1px solid #f0c36d;
-  border-radius: 8px;
-  padding: 10px 20px;
-  margin-bottom: 20px;
-  color: #333;
-  font-size: 16px;
-  text-align: center;
-}
-
-.notification p {
-  margin: 0;
-}
-
-.notification a {
-  color: #007bff;
-  text-decoration: none;
-  font-weight: bold;
-}
-
-.notification a:hover {
-  text-decoration: none;
-}
 
 @media (max-width:480px)  {
   .buyMeACoffee {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,21 @@
-import SearchForm from '../components/SearchForm';
-import { allAirports } from '../lib/data';
+import SearchForm from '@/components/SearchForm';
+import BuyMeACoffee from '@/components/BuyMeACoffee';
+import UpdateNotification from '@/components/UpdateNotification';
+import { allAirports } from '@/lib/data.mjs';
+import styles from '@/app/page.module.css';
 
 export default function Home() {
-    return (
-        <main>
-            <h1>Route Planner</h1>
-            <SearchForm airports={allAirports} />
-        </main>
-    );
+  return (
+    <div className={styles.app}>
+      <h1 className={styles.header}>Route Planner</h1>
+
+      <UpdateNotification/>
+
+      <SearchForm airports={allAirports} />
+
+      <div className={styles.buyMeACoffee}>
+        <BuyMeACoffee />
+      </div>
+    </div>
+  );
 }

--- a/components/UpdateNotification.jsx
+++ b/components/UpdateNotification.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import styles from './UpdateNotification.module.css';
+
+export default function UpdateNotification() {
+  return (
+    <div className={styles.notification}>
+      <p>
+        📅 <strong>Site and timetable updated Jun 13, 2025.</strong>{' '}
+        Report about issues:&nbsp;
+        <a href="mailto:artem@veikus.com">artem@veikus.com</a>
+      </p>
+    </div>
+  );
+}

--- a/components/UpdateNotification.module.css
+++ b/components/UpdateNotification.module.css
@@ -1,0 +1,24 @@
+.notification {
+  background-color: #f9f5e3;
+  border: 1px solid #f0c36d;
+  border-radius: 8px;
+  padding: 10px 20px;
+  margin-bottom: 20px;
+  color: #333;
+  font-size: 16px;
+  text-align: center;
+}
+
+.notification p {
+  margin: 0;
+}
+
+.notification a {
+  color: #007bff;
+  text-decoration: none;
+  font-weight: bold;
+}
+
+.notification a:hover {
+  text-decoration: none;
+}


### PR DESCRIPTION
## Summary
- share page layout file via alias imports
- extract update notice into `UpdateNotification` component
- use `UpdateNotification` on home and results pages

## Testing
- `npm run lint` *(fails: requires ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_684c7e0b3d1c832d8d139224ce451ab6