### PR TITLE
Add Simple Analytics tracker

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -20,10 +20,24 @@ export const metadata = {
 export default function RootLayout({ children }) {
   return (
     <html lang="en">
+      <head></head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         {children}
+        {/* 100% privacy-first analytics */}
+        <script
+          async
+          defer
+          src="https://scripts.simpleanalyticscdn.com/latest.js"
+        ></script>
+        <noscript>
+          <img
+            src="https://queue.simpleanalyticscdn.com/noscript.gif"
+            alt=""
+            referrerPolicy="no-referrer-when-downgrade"
+          />
+        </noscript>
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- include Simple Analytics script and noscript at the end of the root layout's body

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find module '../lib/data')*

------
https://chatgpt.com/codex/tasks/task_e_684c893f3bac832d99c5d36029f39e65