### PR TITLE
Improve flight lookup performance

### DIFF
--- a/lib/susanin.js
+++ b/lib/susanin.js
@@ -1,6 +1,8 @@
 import { allFlights } from './data.mjs';
 import { DateTime } from 'luxon';
 
+const flightsFromCache = new Map();
+
 class Route {
   constructor(legs) {
     this.legs = legs;
@@ -101,9 +103,13 @@ function getFlightForTheDay(flightData, date) {
 
 async function getFlightsFromAirport(from, after, before) {
   const results = [];
-  const relevantFlights = allFlights.filter(flight => flight.from.iata === from);
+  let cachedFlights = flightsFromCache.get(from);
+  if (!cachedFlights) {
+    cachedFlights = allFlights.filter(flight => flight.from.iata === from);
+    flightsFromCache.set(from, cachedFlights);
+  }
 
-  for (const flight of relevantFlights) {
+  for (const flight of cachedFlights) {
     const flights = getFlightsBetween(flight, new Date(after), new Date(before));
     results.push(...flights);
   }


### PR DESCRIPTION
## Summary
- rename cache variable to clarify intent
- keep cached flights lookup variable separate

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684c879a4ad4832d91da91aee1479ea2