### PR TITLE
Implement minTransferTime validation

### DIFF
--- a/app/400/page.js
+++ b/app/400/page.js
@@ -1,0 +1,17 @@
+export const metadata = {
+  title: '400 – Bad Request',
+};
+
+import Link from 'next/link';
+
+export default function BadRequest() {
+  return (
+    <div style={{ padding: '20px', textAlign: 'center' }}>
+      <h1>400 – Bad Request</h1>
+      <p>Invalid parameters provided.</p>
+      <p>
+        <Link href="/">Return to search</Link>
+      </p>
+    </div>
+  );
+}

--- a/app/[from]/[to]/[date]/page.js
+++ b/app/[from]/[to]/[date]/page.js
@@ -5,9 +5,16 @@ import Routes from '@/components/Routes';
 import BuyMeACoffee from '@/components/BuyMeACoffee';
 import Link from 'next/link';
 import styles from './page.module.css';
+import { parseMinTransferHours } from '@/lib/config.js';
+import { redirect } from 'next/navigation';
 
 export default async function Results({ params, searchParams }) {
-  const min = Number(searchParams.minTransferTime ?? 3 * 3600);
+  const raw = searchParams.minTransferTime ?? '3';
+  const minHours = parseMinTransferHours(raw);
+  if (minHours === null) {
+    redirect('/400');
+  }
+  const min = minHours * 3600;
   const routes = await pathFinder(params.from, params.to, params.date, min);
 
   return (

--- a/app/actions.js
+++ b/app/actions.js
@@ -1,12 +1,18 @@
 'use server';
 
 import { pathFinder } from '../lib/susanin';
+import { parseMinTransferHours } from '../lib/config.js';
 
 export async function findRoutes(formData) {
   const from = formData.get('from');
   const to = formData.get('to');
   const date = formData.get('date');
-  const min = Number(formData.get('minTransferTime') ?? 3) * 3600;
+  const raw = formData.get('minTransferTime') ?? '3';
+  const minHours = parseMinTransferHours(raw);
+  if (minHours === null) {
+    throw new Error('Invalid minTransferTime');
+  }
+  const min = minHours * 3600;
 
   return pathFinder(from, to, date, min);
 }

--- a/components/SearchForm.jsx
+++ b/components/SearchForm.jsx
@@ -3,6 +3,7 @@
 import React, { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import styles from './SearchForm.module.css';
+import { MAX_TRANSFER_HOURS, clampMinTransferHours } from '@/lib/config.js';
 
 export default function SearchForm({ airports }) {
   const router = useRouter();
@@ -18,13 +19,12 @@ export default function SearchForm({ airports }) {
     e.preventDefault();
     if (!from || !to || !date) return;
 
-    const maxHours = 72;
-    const minHours = Math.min(minTransferTime, maxHours);
+    const maxHours = MAX_TRANSFER_HOURS;
+    const minHours = clampMinTransferHours(minTransferTime);
 
     let url = `/${from}/${to}/${date}`;
     if (minHours !== 3) {
-      const minSeconds = minHours * 3600;
-      url += `?minTransferTime=${minSeconds}`;
+      url += `?minTransferTime=${minHours}`;
     }
 
     router.push(url);
@@ -101,14 +101,14 @@ export default function SearchForm({ airports }) {
           <div className={styles.section}>
             <div className={`${styles.formGroup} ${styles.minTransferTime}`}>
               <label htmlFor="minTransferTime">
-                Minimum Transfer Time (0 – 72 h):
+                {`Minimum Transfer Time (0 – ${MAX_TRANSFER_HOURS} h):`}
               </label>
               <input
                 type="number"
                 id="minTransferTime"
                 value={minTransferTime}
                 min={0}
-                max={72}
+                max={MAX_TRANSFER_HOURS}
                 onChange={e => setMinTransferTime(Number(e.target.value))}
               />
               {minTransferTime < 3 && (

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,0 +1,14 @@
+export const MAX_TRANSFER_HOURS = 72;
+
+export function clampMinTransferHours(value) {
+  const num = Number(value);
+  if (Number.isNaN(num)) return 0;
+  return Math.min(Math.max(num, 0), MAX_TRANSFER_HOURS);
+}
+
+export function parseMinTransferHours(value) {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return null;
+  if (num < 0 || num > MAX_TRANSFER_HOURS) return null;
+  return num;
+}


### PR DESCRIPTION
## Summary
- add MAX_TRANSFER_HOURS setting and helper
- use config in SearchForm
- clamp minTransferTime in results page and server action
- pass minTransferTime as hours in URL
- show 400 page when minTransferTime param is invalid

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684c8b43b3a4832d99e81012dbf5aa75