### PR TITLE
Centralize components exports

### DIFF
--- a/app/[from]/[to]/[date]/page.js
+++ b/app/[from]/[to]/[date]/page.js
@@ -1,11 +1,8 @@
 import { pathFinder } from '@/lib/susanin';
 import { allAirports } from '@/lib/data.mjs';
-import SearchForm from '@/components/SearchForm';
-import Routes from '@/components/Routes';
-import BuyMeACoffee from '@/components/BuyMeACoffee';
-import Notification from '@/components/Notification';
+import { SearchForm, Routes, BuyMeACoffee, Notification } from '@/components';
 import Link from 'next/link';
-import styles from './page.module.css';
+import styles from '@/app/page.module.css';
 
 export default async function Results({ params, searchParams }) {
   const min = Number(searchParams.minTransferTime ?? 3 * 3600);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,4 @@
-import SearchForm from '@/components/SearchForm';
-import BuyMeACoffee from '@/components/BuyMeACoffee';
-import Notification from '@/components/Notification';
+import { SearchForm, BuyMeACoffee, Notification } from '@/components';
 import { allAirports } from '@/lib/data.mjs';
 import styles from '@/app/page.module.css';
 

--- a/components/index.js
+++ b/components/index.js
@@ -1,0 +1,9 @@
+export { default as BuyMeACoffee } from './BuyMeACoffee';
+export { default as Disclaimer } from './Disclaimer';
+export { default as Notification } from './Notification';
+export { default as Route } from './Route';
+export { default as RouteLeg } from './RouteLeg';
+export { default as Routes } from './Routes';
+export { default as SearchForm } from './SearchForm';
+export { default as TransferInfo } from './TransferInfo';
+


### PR DESCRIPTION
## Summary
- centralize component exports in `components/index.js`
- refactor pages to use the new named exports
- fix route results page styles path

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684c8f6078dc832db76fa1f2600ced30