### PR TITLE
Add Docker setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+npm-debug.log
+.DS_Store
+.next
+.env
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# Install dependencies only when needed
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm ci
+
+# Rebuild the source code only when needed
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build
+
+# Production image, copy necessary files
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=builder /app/next.config.mjs ./next.config.mjs
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/package.json ./package.json
+
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -34,3 +34,13 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+
+## Running with Docker Compose
+
+To run the project using Docker Compose (e.g. on Synology), build and start the container:
+
+```bash
+docker-compose up -d
+```
+
+The application will be available on port `3000`.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,9 @@
+version: '3'
+services:
+  web:
+    build: .
+    ports:
+      - "3000:3000"
+    environment:
+      - NODE_ENV=production
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
- add Dockerfile to build Next.js app
- add docker-compose.yaml for easy startup
- ignore common Docker build artifacts
- document Docker Compose usage in README

## Testing
- `npm run lint` *(fails: Identifier 'styles' has already been declared)*
- `npm run build` *(fails: build failed because of webpack errors)*

------
https://chatgpt.com/codex/tasks/task_e_684c8dba05e0832da2819ef8afacc8bc