### PR TITLE
Restore Disclaimer component name and visibility

### DIFF
--- a/app/[from]/[to]/[date]/page.js
+++ b/app/[from]/[to]/[date]/page.js
@@ -6,7 +6,6 @@ import BuyMeACoffee from '@/components/BuyMeACoffee';
 import Notification from '@/components/Notification';
 import styles from '@/app/page.module.css';
 import Link from 'next/link';
-import styles from './page.module.css';
 
 export default async function Results({ params, searchParams }) {
   const min = Number(searchParams.minTransferTime ?? 3 * 3600);

--- a/components/Disclaimer.jsx
+++ b/components/Disclaimer.jsx
@@ -1,27 +1,24 @@
 'use client';
 
-import React, { useState, useEffect } from "react";
-import styles from "./Disclaimer.module.css";
+import React, { useState, useEffect } from 'react';
+import styles from './Disclaimer.module.css';
 
 const Disclaimer = () => {
   const [isVisible, setIsVisible] = useState(false);
 
   useEffect(() => {
-    if (typeof window !== "undefined") {
-      const savedVisibility = localStorage.getItem("disclaimerVisible");
-      if (savedVisibility !== null) {
-        setIsVisible(JSON.parse(savedVisibility));
-      } else {
+    if (typeof window !== 'undefined') {
+      const isHidden = localStorage.getItem('disclaimerHidden');
+      console.log('xxxx', isHidden);
+      if (isHidden === null) {
         setIsVisible(true);
       }
     }
   }, []);
 
   const handleHide = () => {
+    localStorage.setItem('disclaimerHidden', 'true');
     setIsVisible(false);
-    if (typeof window !== "undefined") {
-      localStorage.setItem("disclaimerVisible", false);
-    }
   };
 
   if (!isVisible) {

--- a/components/Disclaimer.jsx
+++ b/components/Disclaimer.jsx
@@ -4,18 +4,24 @@ import React, { useState, useEffect } from "react";
 import styles from "./Disclaimer.module.css";
 
 const Disclaimer = () => {
-  const [isVisible, setIsVisible] = useState(true);
+  const [isVisible, setIsVisible] = useState(false);
 
   useEffect(() => {
-    const savedVisibility = localStorage.getItem("disclaimerVisible");
-    if (savedVisibility !== null) {
-      setIsVisible(JSON.parse(savedVisibility));
+    if (typeof window !== "undefined") {
+      const savedVisibility = localStorage.getItem("disclaimerVisible");
+      if (savedVisibility !== null) {
+        setIsVisible(JSON.parse(savedVisibility));
+      } else {
+        setIsVisible(true);
+      }
     }
   }, []);
 
   const handleHide = () => {
     setIsVisible(false);
-    localStorage.setItem("disclaimerVisible", false);
+    if (typeof window !== "undefined") {
+      localStorage.setItem("disclaimerVisible", false);
+    }
   };
 
   if (!isVisible) {
@@ -40,9 +46,7 @@ const Disclaimer = () => {
       <p className={styles.disclaimerText}>
         Please note that WizzAir sells separate tickets for each leg of your journey. If you miss a connection due to a delay or any other reason, it is your responsibility to ensure you catch your next flight, as WizzAir does not guarantee connections between their flights.
       </p>
-      <p className={styles.disclaimerText}>
-        We wish you a pleasant journey!
-      </p>
+      <p className={styles.disclaimerText}>We wish you a pleasant journey!</p>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- revert the Rules rename back to Disclaimer
- hide Disclaimer by default on initial render
- import the Disclaimer component in Routes

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684c8d9a5138832db4904c2b5a387b50