### PR TITLE
Refactor airport validation with helper

### DIFF
--- a/app/[from]/[to]/[date]/page.js
+++ b/app/[from]/[to]/[date]/page.js
@@ -1,19 +1,31 @@
 import { pathFinder } from '@/lib/susanin';
 import { allAirports } from '@/lib/data.mjs';
+import { airportExists } from '@/lib/airports.js';
 import { SearchForm, Routes, BuyMeACoffee, Notification } from '@/components';
 import Link from 'next/link';
-import { redirect } from 'next/navigation';
+import { redirect, notFound } from 'next/navigation';
 import styles from '@/app/page.module.css';
 import { parseMinTransferHours } from '@/lib/config.js';
 
 export default async function Results({ params, searchParams }) {
+  const { from, to, date } = params;
+
+  function isValidDate(value) {
+    const d = new Date(value);
+    return !Number.isNaN(d.getTime()) && d.toISOString().slice(0, 10) === value;
+  }
+
+  if (!isValidDate(date) || !airportExists(from) || !airportExists(to)) {
+    notFound();
+  }
+
   const raw = searchParams.minTransferTime ?? '3';
   const minHours = parseMinTransferHours(raw);
   if (minHours === null) {
     redirect('/400');
   }
   const min = minHours * 3600;
-  const routes = await pathFinder(params.from, params.to, params.date, min);
+  const routes = await pathFinder(from, to, date, min);
 
   return (
     <div className={styles.app}>

--- a/lib/airports.js
+++ b/lib/airports.js
@@ -1,0 +1,7 @@
+import { allAirports } from './data.mjs';
+
+const airportSet = new Set(allAirports.map(a => a.iata));
+
+export function airportExists(iata) {
+  return airportSet.has(iata);
+}


### PR DESCRIPTION
## Summary
- create `airportExists` helper in `lib/airports.js`
- use the helper for validating airport codes in the dynamic results page

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684c973f4f6c832da322ab0264a99a27