### PR TITLE
Prefill search form from URL

### DIFF
--- a/app/[from]/[to]/[date]/page.js
+++ b/app/[from]/[to]/[date]/page.js
@@ -55,7 +55,13 @@ export default async function Results({ params, searchParams }) {
 
         <Notification/>
 
-      <SearchForm airports={allAirports}/>
+      <SearchForm
+        airports={allAirports}
+        defaultFrom={from}
+        defaultTo={to}
+        defaultDate={date}
+        defaultMinTransferTime={minHours}
+      />
 
       <div className={styles.buyMeACoffee}>
         <BuyMeACoffee/>

--- a/components/SearchForm.jsx
+++ b/components/SearchForm.jsx
@@ -5,15 +5,23 @@ import { useRouter } from 'next/navigation';
 import styles from './SearchForm.module.css';
 import { MAX_TRANSFER_HOURS, clampMinTransferHours } from '@/lib/config.js';
 
-export default function SearchForm({ airports }) {
+export default function SearchForm({
+  airports,
+  defaultFrom = '',
+  defaultTo = '',
+  defaultDate,
+  defaultMinTransferTime = 3,
+}) {
   const router = useRouter();
   const today = new Date().toISOString().split('T')[0];
 
-  const [from, setFrom] = useState('');
-  const [to, setTo] = useState('');
-  const [date, setDate] = useState(today);
-  const [minTransferTime, setMinTransferTime] = useState(3); // часы
-  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [from, setFrom] = useState(defaultFrom);
+  const [to, setTo] = useState(defaultTo);
+  const [date, setDate] = useState(defaultDate ?? today);
+  const [minTransferTime, setMinTransferTime] = useState(defaultMinTransferTime);
+  const [showAdvanced, setShowAdvanced] = useState(
+    defaultMinTransferTime !== 3
+  );
 
   const handleSubmit = (e) => {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- allow `SearchForm` to accept default values
- populate `SearchForm` in results page using route params
- clean up leftover comment

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684ca2a8a92c832db829a9fe180ba901