### PR TITLE
Fix SearchForm defaultDate prop

### DIFF
--- a/components/SearchForm.jsx
+++ b/components/SearchForm.jsx
@@ -9,7 +9,7 @@ export default function SearchForm({
   airports,
   defaultFrom = '',
   defaultTo = '',
-  defaultDate,
+  defaultDate = undefined,
   defaultMinTransferTime = 3,
 }) {
   const router = useRouter();


### PR DESCRIPTION
## Summary
- make `defaultDate` optional in `SearchForm` so TypeScript callers aren't forced to pass it

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684caa0b646c832da161ad27587cbdc7