### PR TITLE
Display loading message during search

### DIFF
--- a/app/[from]/[to]/[date]/loading.js
+++ b/app/[from]/[to]/[date]/loading.js
@@ -1,0 +1,20 @@
+import Link from 'next/link';
+import styles from '@/app/page.module.css';
+import routeStyles from '@/components/Routes.module.css';
+import { Notification } from '@/components';
+
+export default function Loading() {
+  return (
+    <div className={styles.app}>
+      <h1 className={styles.header}>
+        <Link href="/">Route Planner</Link>
+      </h1>
+
+      <Notification />
+
+      <p className={routeStyles.noSearchResults}>
+        Loading... It takes around ~5 seconds. Please, be patient
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- show a loading page when routes are loading

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684cc159da98832dbafb9434ad1e6aa3