### PR TITLE
Add flight_schedule initdb schema

### DIFF
--- a/initdb/001-init.sql
+++ b/initdb/001-init.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS flight_schedule (
+  flight_id        VARCHAR(32) NOT NULL,
+  flight_number    VARCHAR(16) NOT NULL,
+  flight_date      DATE        NOT NULL,
+  std_local        DATETIME    NOT NULL,
+  sta_local        DATETIME    NOT NULL,
+  std_utc          DATETIME    NOT NULL,
+  sta_utc          DATETIME    NOT NULL,
+  std_offset_min   SMALLINT    NOT NULL,
+  sta_offset_min   SMALLINT    NOT NULL,
+  flight_time_min  SMALLINT    NOT NULL,
+  from_iata        CHAR(3)     NOT NULL,
+  to_iata          CHAR(3)     NOT NULL,
+  from_city        VARCHAR(64) NOT NULL,
+  to_city          VARCHAR(64) NOT NULL,
+  PRIMARY KEY (flight_id),
+  KEY idx_from_std (from_iata, std_utc),
+  KEY idx_to_sta (to_iata, sta_utc)
+);


### PR DESCRIPTION
## Summary
- initialize database schema with `initdb/001-init.sql`
- mount the `initdb` directory into MySQL using docker-compose

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684dd32ccd8c832da7d7dfb305f6fc63