### PR TITLE
Use env vars for DB connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,17 @@ docker-compose up -d
 ```
 
 The application will be available on port `3000`.
+
+## Environment Variables
+
+Database connection parameters are configured with the following variables:
+
+| Variable  | Description                      |
+|-----------|----------------------------------|
+| `DB_HOST` | Database host (e.g. `127.0.0.1`) |
+| `DB_PORT` | Database port (e.g. `13306`)     |
+| `DB_NAME` | Database name                    |
+| `DB_USER` | Database user                    |
+| `DB_PASS` | Database password                |
+
+All of these variables are required. You can provide them in a `.env` file or rely on `docker-compose` which sets them automatically.

--- a/generate-schedule.js
+++ b/generate-schedule.js
@@ -4,14 +4,21 @@ import mysql from 'mysql2/promise';
 import { getFlightForTheDay } from './lib/susanin.js';
 import { getFlights } from './lib/data.js'; // твои «сырцы» из data.js
 
+const { DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASS } = process.env;
+
+if (!DB_HOST || !DB_PORT || !DB_NAME || !DB_USER || !DB_PASS) {
+  console.error('Missing database configuration. Set DB_HOST, DB_PORT, DB_NAME, DB_USER and DB_PASS.');
+  process.exit(1);
+}
+
 const pool = mysql.createPool({
-  host:     '127.0.0.1',
-  port:     '13306',
-  user:     'flight_bot',
-  password: 'secret',
-  database: 'flights',
-  timezone: 'Z',        // получать/отдавать DATETIME как UTC-строки
-  dateStrings: true,    // не превратить DATE в JS-Date с локальным смещением
+  host: DB_HOST,
+  port: DB_PORT,
+  user: DB_USER,
+  password: DB_PASS,
+  database: DB_NAME,
+  timezone: 'Z',
+  dateStrings: true,
 });
 
 const BATCH = 1_000;    // сколько строк отправляем одним INSERT

--- a/lib/susanin.js
+++ b/lib/susanin.js
@@ -4,12 +4,20 @@ import mysql from 'mysql2/promise';
 import { start } from 'node:repl';
 
 const flightsFromCache = new Map();
+
+const { DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASS } = process.env;
+
+if (!DB_HOST || !DB_PORT || !DB_NAME || !DB_USER || !DB_PASS) {
+  console.error('Missing database configuration. Set DB_HOST, DB_PORT, DB_NAME, DB_USER and DB_PASS.');
+  process.exit(1);
+}
+
 const pool = mysql.createPool({
-  host:     '127.0.0.1',
-  port:     '13306',
-  user:     'flight_bot',
-  password: 'secret',
-  database: 'flights',
+  host: DB_HOST,
+  port: DB_PORT,
+  user: DB_USER,
+  password: DB_PASS,
+  database: DB_NAME,
   timezone: 'Z',
   dateStrings: true,
 });


### PR DESCRIPTION
## Summary
- use database credentials strictly from env vars
- exit if mandatory variables are missing
- document required variables

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684dd3329e1c832d86ceee6a6bc6d229