### PR TITLE
Centralize MySQL pool

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -1,0 +1,24 @@
+import mysql from 'mysql2/promise';
+
+const { DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASS } = process.env;
+
+if (!DB_HOST || !DB_PORT || !DB_NAME || !DB_USER || !DB_PASS) {
+  console.error('Missing database configuration. Set DB_HOST, DB_PORT, DB_NAME, DB_USER and DB_PASS.');
+  process.exit(1);
+}
+
+const pool = mysql.createPool({
+  host: DB_HOST,
+  port: DB_PORT,
+  user: DB_USER,
+  password: DB_PASS,
+  database: DB_NAME,
+  timezone: 'Z',
+  dateStrings: true,
+});
+
+export default pool;
+
+export async function endPool() {
+  await pool.end();
+}

--- a/lib/susanin.js
+++ b/lib/susanin.js
@@ -1,26 +1,9 @@
 import { getFlights, getAirportByIata } from './data.js';
 import { DateTime } from 'luxon';
-import mysql from 'mysql2/promise';
-import { start } from 'node:repl';
+import pool from './db.js';
 
 const flightsFromCache = new Map();
 
-const { DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASS } = process.env;
-
-if (!DB_HOST || !DB_PORT || !DB_NAME || !DB_USER || !DB_PASS) {
-  console.error('Missing database configuration. Set DB_HOST, DB_PORT, DB_NAME, DB_USER and DB_PASS.');
-  process.exit(1);
-}
-
-const pool = mysql.createPool({
-  host: DB_HOST,
-  port: DB_PORT,
-  user: DB_USER,
-  password: DB_PASS,
-  database: DB_NAME,
-  timezone: 'Z',
-  dateStrings: true,
-});
 
 class Route {
   constructor(legs) {


### PR DESCRIPTION
## Summary
- centralize database pool creation under `lib/db.js`
- reuse shared pool in `generate-schedule.js` and `lib/susanin.js`
- remove unused REPL import
- expose `endPool` helper to close the connection gracefully

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684dd5748c30832d9052d3b1b6b91bb6