### PR TITLE
Add DB airport helpers

### DIFF
--- a/app/[from]/[to]/[date]/page.js
+++ b/app/[from]/[to]/[date]/page.js
@@ -1,6 +1,5 @@
 import { pathFinder } from '@/lib/susanin';
-import { getAirports, airportExists } from '@/lib/data.js';
-import { getAirportByIata } from '@/lib/db.js';
+import { getAirports, airportExists, getAirportByIata } from '@/lib/db.js';
 import { SearchForm, Routes, BuyMeACoffee, Notification } from '@/components';
 import Link from 'next/link';
 import { redirect, notFound } from 'next/navigation';
@@ -33,12 +32,18 @@ export default async function Results({ params, searchParams }) {
   const { from, to, date } = await params;
   const { minTransferTime } = await searchParams;
 
+  const airports = await getAirports();
+
   function isValidDate(value) {
     const d = new Date(value);
     return !Number.isNaN(d.getTime()) && d.toISOString().slice(0, 10) === value;
   }
 
-  if (!isValidDate(date) || !airportExists(from) || !airportExists(to)) {
+  if (
+    !isValidDate(date) ||
+    !(await airportExists(from)) ||
+    !(await airportExists(to))
+  ) {
     notFound();
   }
 
@@ -58,7 +63,7 @@ export default async function Results({ params, searchParams }) {
         <Notification/>
 
       <SearchForm
-        airports={getAirports()}
+        airports={airports}
         defaultFrom={from}
         defaultTo={to}
         defaultDate={date}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,5 @@
 import { SearchForm, BuyMeACoffee, Notification } from '@/components';
-import { getAirports } from '@/lib/data.js';
+import { getAirports } from '@/lib/db.js';
 import styles from '@/app/page.module.css';
 
 export const revalidate = 86_400;
@@ -14,14 +14,15 @@ export const metadata = {
   },
 };
 
-export default function Home() {
+export default async function Home() {
+  const airports = await getAirports();
   return (
     <div className={styles.app}>
       <h1 className={styles.header}>Route Planner</h1>
 
         <Notification/>
 
-      <SearchForm airports={getAirports()} />
+      <SearchForm airports={airports} />
 
       <div className={styles.buyMeACoffee}>
         <BuyMeACoffee />

--- a/lib/db.js
+++ b/lib/db.js
@@ -30,3 +30,15 @@ export async function getAirportByIata(iata) {
   );
   return rows[0] || null;
 }
+
+export async function getAirports() {
+  const [rows] = await pool.execute(
+    'SELECT iata, name FROM airports ORDER BY name'
+  );
+  return rows;
+}
+
+export async function airportExists(iata) {
+  const airport = await getAirportByIata(iata);
+  return !!airport;
+}


### PR DESCRIPTION
## Summary
- add `getAirports` and `airportExists` helpers to db layer
- fetch airports from database on the home page
- use db airport helpers on results page
- remove airports cache

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684ded8999e0832da28f86ed9bd34054