### PR TITLE
Run schedule generator in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,19 @@ RUN npm ci
 # Rebuild the source code only when needed
 FROM node:20-alpine AS builder
 WORKDIR /app
+ARG DB_HOST=db
+ARG DB_PORT=3306
+ARG DB_NAME=flights
+ARG DB_USER=flight_bot
+ARG DB_PASS=secret
+ENV DB_HOST=$DB_HOST \
+    DB_PORT=$DB_PORT \
+    DB_NAME=$DB_NAME \
+    DB_USER=$DB_USER \
+    DB_PASS=$DB_PASS
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
+RUN npm run generate-schedule
 RUN npm run build
 
 # Production image, copy necessary files

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,7 +18,14 @@ services:
       - ./initdb:/docker-entrypoint-initdb.d
 
   web:
-    build: .
+    build:
+      context: .
+      args:
+        DB_HOST: db
+        DB_PORT: 3306
+        DB_NAME: flights
+        DB_USER: flight_bot
+        DB_PASS: secret
     depends_on:
       - db
     ports:


### PR DESCRIPTION
## Summary
- generate flight schedule data during build
- pass DB credentials to Docker build via args

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684dfc478dbc832db4bb45263c09ec35