### PR TITLE
Add previous/next day navigation

### DIFF
--- a/app/[from]/[to]/[date]/page.js
+++ b/app/[from]/[to]/[date]/page.js
@@ -54,6 +54,15 @@ export default async function Results({ params, searchParams }) {
   }
   const routes = await pathFinder(from, to, date, minHours);
 
+  const prevDate = new Date(date);
+  prevDate.setDate(prevDate.getDate() - 1);
+  const nextDate = new Date(date);
+  nextDate.setDate(nextDate.getDate() + 1);
+  const query = minHours !== 3 ? `?minTransferTime=${minHours}` : '';
+
+  const prevUrl = `/${from}/${to}/${prevDate.toISOString().slice(0, 10)}${query}`;
+  const nextUrl = `/${from}/${to}/${nextDate.toISOString().slice(0, 10)}${query}`;
+
   return (
     <div className={styles.app}>
       <h1 className={styles.header}>
@@ -69,6 +78,11 @@ export default async function Results({ params, searchParams }) {
         defaultDate={date}
         defaultMinTransferTime={minHours}
       />
+
+      <div className={styles.dayNav}>
+        <Link href={prevUrl}>← Previous Day</Link>
+        <Link href={nextUrl}>Next Day →</Link>
+      </div>
 
       <div className={styles.buyMeACoffee}>
         <BuyMeACoffee/>

--- a/app/[from]/[to]/[date]/page.js
+++ b/app/[from]/[to]/[date]/page.js
@@ -69,7 +69,7 @@ export default async function Results({ params, searchParams }) {
         <Link href="/">Route Planner</Link>
       </h1>
 
-        <Notification/>
+      <Notification/>
 
       <SearchForm
         airports={airports}
@@ -79,13 +79,13 @@ export default async function Results({ params, searchParams }) {
         defaultMinTransferTime={minHours}
       />
 
+      <div className={styles.buyMeACoffee}>
+        <BuyMeACoffee/>
+      </div>
+
       <div className={styles.dayNav}>
         <Link href={prevUrl}>← Previous Day</Link>
         <Link href={nextUrl}>Next Day →</Link>
-      </div>
-
-      <div className={styles.buyMeACoffee}>
-        <BuyMeACoffee/>
       </div>
 
       <Routes keyPrefix={`${from}-${to}-${date}-${minHours}`} routes={routes}/>

--- a/app/page.module.css
+++ b/app/page.module.css
@@ -22,6 +22,22 @@
   right: 10px;
 }
 
+.dayNav {
+  display: flex;
+  justify-content: space-between;
+  margin: 10px 0;
+}
+
+.dayNav a {
+  color: #007bff;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.dayNav a:hover {
+  text-decoration: underline;
+}
+
 
 @media (max-width:480px)  {
   .buyMeACoffee {


### PR DESCRIPTION
## Summary
- add Previous/Next day links on the results page
- style the new navigation links

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684ec9971980832da4d6646b6691c2d7